### PR TITLE
Improve spacing for two argument predicates

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -163,6 +163,10 @@
 
 \renewcommand{\Prop}{\mProp}
 
+% Multiple argument macros
+\newcommand{\isList}[2]{\operatorname{isList} #1 \spac #2}
+\newcommand{\map}[2]{\operatorname{map} #1 \spac #2}
+
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "main"

--- a/macros.tex
+++ b/macros.tex
@@ -166,6 +166,8 @@
 % Multiple argument macros
 \newcommand{\isList}[2]{\operatorname{isList} #1 \spac #2}
 \newcommand{\map}[2]{\operatorname{map} #1 \spac #2}
+\newcommand{\listFilter}[2]{\operatorname{listFilter} #1 \spac #2}
+\newcommand{\all}[2]{\operatorname{all} #1 \spac #2}
 
 %%% Local Variables:
 %%% mode: latex

--- a/macros.tex
+++ b/macros.tex
@@ -163,11 +163,12 @@
 
 \renewcommand{\Prop}{\mProp}
 
-% Multiple argument macros
-\newcommand{\isList}[2]{\operatorname{isList} #1 \spac #2}
-\newcommand{\map}[2]{\operatorname{map} #1 \spac #2}
-\newcommand{\listFilter}[2]{\operatorname{listFilter} #1 \spac #2}
-\newcommand{\all}[2]{\operatorname{all} #1 \spac #2}
+% Multiple argument macros with consistent spacing
+\newcommand{\twoArgMacro}[2]{\newcommand{#1}[2]{#2 ##1 \spac ##2}}
+\twoArgMacro{\isList}{\operatorname{isList}}
+\twoArgMacro{\map}{\operatorname{map}}
+\twoArgMacro{\listFilter}{\operatorname{listFilter}}
+\twoArgMacro{\all}{\operatorname{all}}
 
 %%% Local Variables:
 %%% mode: latex

--- a/main.tex
+++ b/main.tex
@@ -139,10 +139,11 @@
   Mathias H{\o}ier (Aarhus University),
   Robbert Krebbers (Aarhus University / Delft University of Technology),
   Marit Edna Ohlenbusch (Aarhus University),
-  Amin Timany (KU Leuven / Aarhus Univeristy),
+  Amin Timany (KU Leuven / Aarhus University),
   Simon Friis Vindum (Aarhus University),
   Felix Wiemuth (Aarhus University),
-  Jonas Kastberg Hinrichsen (Aarhus University).
+  Jonas Kastberg Hinrichsen (Aarhus University),
+  Dorian Lesbre (ENS Paris / Aarhus University).
 \end{minipage}
 
 \newpage

--- a/sections/basic-separation-logic.tex
+++ b/sections/basic-separation-logic.tex
@@ -732,6 +732,9 @@ granularity exemplified by the following exercise.
 
 \subsection{Reasoning about Mutable Data Structures}
 
+\newcommand{\isList}[2]{\operatorname{isList}~#1~#2}
+\newcommand{\map}[2]{\operatorname{map}~#1~#2}
+
 In the following examples we will work with linked lists -- chains of
 reference cells with forward links.  In order to specify their
 behaviour we assume (as explained in
@@ -749,17 +752,17 @@ inductively defined data structure in the sense known from statically
 typed funtional languages like ML or Coq -- it mimics the shape, but
 nothing inherently prevents the formation of, \eg{} cyclical lists.
 
-The $\operatorname{isList} l xs$ predicate relates 
+The $\isList {l} {xs}$ predicate relates 
 values $l$ to sequences $xs$; it is 
 defined by induction on $xs$:
 \begin{align*}
-  &\operatorname{isList} l [] \equiv l = \langkw{inj}_1()\\
-  &\operatorname{isList} l (x::xs) \equiv \Exists hd, l'. l = \langkw{inj}_2(hd) * hd \pointsto (x,l') * \operatorname{isList} l' xs
+  &\isList {l} {[]} \equiv l = \langkw{inj}_1()\\
+  &\isList {l} {(x::xs)} \equiv \Exists hd, l'. l = \langkw{inj}_2(hd) * hd \pointsto (x,l') * \isList {l'} {xs}
 \end{align*}
 %
 Notice that while our data representation in itself does not 
 ensure the absence of, \eg{}
-cyclic lists, the $\operatorname{isList} l xs$ predicate above 
+cyclic lists, the $\isList {l} {xs}$ predicate above 
 does ensure that the list $l$ is acyclic, because of
 separation of the $hd$ pointer and the inductive
 occurrence of the predicate.
@@ -773,8 +776,8 @@ To specify the next example we assume the $\operatorname{map}$ function on seque
 It is the logical function from sequences to sequences that applies $f$ at every index of the sequence:
 it is defined by the following two equations
 \begin{align*}
-  &\operatorname{map} f [] \equiv []\\
-  &\operatorname{map} f (x::xs) \equiv f x :: \operatorname{map} f xs
+  &\map{f}{[]} \equiv []\\
+  &\map{f}{(x::xs)} \equiv f x :: \map{f}{xs}
 \end{align*}
 
 
@@ -788,9 +791,9 @@ it is defined by the following two equations
   We wish to give it the following specification:
   \begin{mathpar}
     \forall xs.\forall l.
-    \hoare{\operatorname{isList} l xs}%
+    \hoare{\isList {l} {xs}}%
                 {\langkw{inc}\, l}%
-                {v.v=() \wedge \operatorname{isList} l (\operatorname{map} (1+) xs)}
+                {v.v=() \wedge \isList {l} {(\map {(1+)} {xs})}}
 \end{mathpar}
 %
 We proceed by the \ruleref{Ht-Rec} rule and we consider two cases: we
@@ -799,11 +802,11 @@ $x$ followed by another sequence $xs'$.
   
 In the first case we need to show
 \begin{mathpar}
-  \forall l.\hoare{\operatorname{isList} l []}{\langkw{match}\, l\, \langkw{with} ...}{v.v=() \wedge \operatorname{isList} l (\operatorname{map} (1+) [])}
+  \forall l.\hoare{\isList {l} {[]}}{\langkw{match}\, l\, \langkw{with} ...}{v.v=() \wedge \isList {l} {(\map {(1+)} {[]})}}
 \end{mathpar}
 and in the second
 \begin{mathpar}
-\forall x,xs'.\forall l.\hoare{\operatorname{isList} l (x::xs')}{\langkw{match}\, l\, \langkw{with} ...}{v.v=() \wedge \operatorname{isList} l (\operatorname{map} (1+) (x::xs'))}
+\forall x,xs'.\forall l.\hoare{\isList {l} {(x::xs')}}{\langkw{match}\, l\, \langkw{with} ...}{v.v=() \wedge \isList {l} {(\map {(1+)} {(x::xs')})}}
 \end{mathpar}
 where in the body we have replaced $\langkw{inc}$ with the function
 $f$ for which we assume the triple (the assumption of the premise of
@@ -811,7 +814,7 @@ the \ruleref{Ht-Rec} rule)
 \begin{align}
   \label{eq:list-inc-recursion-hyp}
   \forall xs.\forall l.
-  \hoare{\operatorname{isList} l xs}{f l}{v.v=() \wedge \operatorname{isList} l (\operatorname{map} (1+) xs)}.
+  \hoare{\isList {l} {xs}}{f l}{v.v=() \wedge \isList {l} {(\map {(1+)} {xs})}}.
 \end{align}
 %
 In both cases we proceed by the derived match rule from
@@ -820,29 +823,29 @@ predicate tells us enough information to determine the chosen branch
 of the match statement.
 
 In the first case we have
-$\operatorname{isList} l [] \equiv l = \langkw{inj}_1()$, and thus we
+$\isList {l} {[]} \equiv l = \langkw{inj}_1()$, and thus we
 easily prove
 \begin{mathpar}
-  \hoare{\operatorname{isList} l []}{l}{v.v=\Inj1() * \operatorname{isList} l []}
+  \hoare{\isList {l} {[]}}{l}{v.v=\Inj1() * \isList {l} {[]}}
 \end{mathpar}
 by \ruleref{Ht-frame} and \ruleref{Ht-Pre-Eq} followed by \ruleref{Ht-ret}.
 
 Thus we know the first branch is taken and so according to the derived match rule from Exercise~\ref{exercise:derived-match-rule} we need to show the following triple.
 \begin{mathpar}
-  \hoare{\operatorname{isList} l []}{()}{v.v=() * \operatorname{isList} l (\operatorname{map} (+1) [])} 
+  \hoare{\isList {l} {[]}}{()}{v.v=() * \isList {l} {(\map {(+1)} {[]})}} 
 \end{mathpar}
-which follows by \ruleref{Ht-ret} after framing away $\operatorname{isList} l []$, which is allowed as $\operatorname{map} (+1) [] \equiv []$.
+which follows by \ruleref{Ht-ret} after framing away $\isList {l} {[]}$, which is allowed as $\map {(+1)} {[]} \equiv []$.
 
 In the case where the sequence is not empty we have that
 \begin{align*}
-  \operatorname{isList} l (x::xs) \equiv \exists hd, l'. l = \Inj2 hd * hd \pointsto (x,l') * \operatorname{isList} l' xs'
+  \isList {l} {(x::xs)} \equiv \exists hd, l'. l = \Inj2 hd * hd \pointsto (x,l') * \isList {l'} {xs'}
 \end{align*}
 and thus we can prove
 \begin{align*}
   \hoareV
-  { l = \Inj2 hd * hd \pointsto (x,l') * \operatorname{isList} l' xs'}
+  { l = \Inj2 hd * hd \pointsto (x,l') * \isList {l'} {xs'}}
   {l}
-  {r.r=\Inj2 hd * l = \Inj2 hd * hd \pointsto (x,l') * \operatorname{isList} l' xs'}
+  {r.r=\Inj2 hd * l = \Inj2 hd * hd \pointsto (x,l') * \isList {l'} {xs'}}
 \end{align*}
 for some $l'$ and $hd$, using the rule \ruleref{Ht-exist}, the frame rule, the \ruleref{Ht-Pre-Eq} rule, and the \ruleref{Ht-ret} rule.
 \begin{exercise}
@@ -852,29 +855,29 @@ for some $l'$ and $hd$, using the rule \ruleref{Ht-exist}, the frame rule, the \
 This is enough to determine that the match takes the second branch, and using the derived match rule from Exercise~\ref{exercise:derived-match-rule} we proceed to verify the body of the second branch.
 Using the rules \ruleref{Ht-let-det-temp} and \ruleref{Ht-Proj} repeatedly we quickly prove 
 \begin{align*}
-  \hoareV{ l = \Inj2 hd * hd \pointsto (x,l') * \operatorname{isList} l' xs'}
+  \hoareV{ l = \Inj2 hd * hd \pointsto (x,l') * \isList {l'} {xs'}}
   {\begin{array}{l}
      \Let h = \Proj1 !hd in\\
      \Let t = \Proj2 !hd in\\
      hd \gets (h + 1, t)
    \end{array}}
-  {l = \Inj2 hd * hd \pointsto (x + 1,l') * \operatorname{isList} l' xs' * t = l' * h = x}
+  {l = \Inj2 hd * hd \pointsto (x + 1,l') * \isList {l'} {xs'} * t = l' * h = x}
 \end{align*}
 Now
 \begin{align*}
-  l = \Inj2 hd * hd \pointsto (x + 1,l') * \operatorname{isList} l' xs' * t = l' * h = x
+  l = \Inj2 hd * hd \pointsto (x + 1,l') * \isList {l'} {xs'} * t = l' * h = x
 \end{align*}
 clearly implies
 \begin{align*}
-  l = \Inj2 hd * hd \pointsto (x + 1,l') * \operatorname{isList} t xs'
+  l = \Inj2 hd * hd \pointsto (x + 1,l') * \isList {t} {xs'}
 \end{align*}
 and thus, by the sequencing rule \ruleref{Ht-seq-temp} and the rule of
 consequence \ruleref{Ht-csq}, we are left with proving
 \begin{align*}
   \hoareV
-  {l = \Inj2 hd * hd \pointsto (x + 1,l') * \operatorname{isList} t xs'}
+  {l = \Inj2 hd * hd \pointsto (x + 1,l') * \isList {t} {xs'}}
   {f t}
-  {r.r= () * \operatorname{isList} l (\operatorname{map} (+1) (x::xs'))}
+  {r.r= () * \isList {l} {(\map {(+1)} {(x::xs')})}}
 \end{align*}
 which follows from the induction hypothesis~\eqref{eq:list-inc-recursion-hyp}, and the definition of the $\operatorname{isList}$ predicate.
 \end{example}
@@ -923,14 +926,14 @@ which follows from the induction hypothesis~\eqref{eq:list-inc-recursion-hyp}, a
   \end{displaymath}
   We wish to give it the following specification where $\mdoubleplus$ is append on mathematical sequences.
   \begin{displaymath}
-    \forall xs, ys, l, l'.\hoare{\operatorname{isList} l\, xs \ast \operatorname{isList} l'\,ys}{\langkw{append}\,l\,l'}{v.\operatorname{isList} v\,(xs \mdoubleplus ys)}.
+    \forall xs, ys, l, l'.\hoare{\isList {l} {xs} \ast \isList {l'} {ys}}{\langkw{append}\,l\,l'}{v.\isList {v} {(xs \mdoubleplus ys)}}.
   \end{displaymath}
 
   \begin{itemize}
   \item Prove the specification.
   \item Is the following specification also valid?
     \begin{align*}
-      \forall xs, ys, l, l'.\hoare{\operatorname{isList} l\, xs \land \operatorname{isList} l'\,ys}{\langkw{append}\,l\,l'}{v.\operatorname{isList} v\,(xs \mdoubleplus ys)}
+      \forall xs, ys, l, l'.\hoare{\isList {l} {xs} \land \isList {l'} {ys}}{\langkw{append}\,l\,l'}{v.\isList {v} {(xs \mdoubleplus ys)}}
     \end{align*}
     Hint: Think about what is the result of $\langkw{append}\,l\,l$.
   \end{itemize}
@@ -979,7 +982,7 @@ is defined as follows:
   Intuitively we wish to give it the following specification:
   \begin{mathpar}
     \forall vs.\forall hd.
-    \hoare{\operatorname{isList} hd~vs}{\langkw{rev}(hd,\Inj1 ())}{r. \operatorname{isList} r~(\operatorname{reverse} vs)}
+    \hoare{\isList {hd} {vs}}{\langkw{rev}(hd,\Inj1 ())}{r. \isList {r} {(\operatorname{reverse} vs)}}
   \end{mathpar}
 
   The resulting induction hypothesis is, however, not strong enough,
@@ -990,7 +993,7 @@ is defined as follows:
   
   We generalize the specification of \langkw{rev} to the following specification:
   \begin{mathpar}
-    \forall vs, us.\forall hd,acc.\hoare{\operatorname{isList} hd\ vs * \operatorname{isList} acc\ us}{\langkw{rev}(hd,acc)}{r. \operatorname{isList} r (\operatorname{reverse} vs \mdoubleplus us)}
+    \forall vs, us.\forall hd,acc.\hoare{\isList {hd} {vs} * \isList {acc} {us} }{\langkw{rev}(hd,acc)}{r. \isList {r} {(\operatorname{reverse} vs \mdoubleplus us)}}
   \end{mathpar}
 
   \begin{exercise}
@@ -1015,11 +1018,11 @@ is defined as follows:
 
   If $vs=[]$, we argue that
   \begin{mathpar}
-    \hoare{\operatorname{isList} l~[] * \operatorname{isList} acc~us}{l}{r.r=\Inj1() * \operatorname{isList} acc~us}
+    \hoare{\isList {l} {[]} * \isList {acc} {us}}{l}{r.r=\Inj1() * \isList {acc} {us}}
   \end{mathpar}
   and thus by using the derived rule for match from Exercise~\ref{exercise:derived-match-rule} we need to show the following triple for the first branch of the match.
   \begin{mathpar}
-    \hoare{\operatorname{isList} acc~us}{acc}{r.\operatorname{isList} r (\operatorname{reverse} [] \mdoubleplus us)}
+    \hoare{\isList {acc} {us}}{acc}{r.\isList {r} {(\operatorname{reverse} [] \mdoubleplus us)}}
   \end{mathpar}
   This is easily seen to hold as $\operatorname{reverse} [] \mdoubleplus us \equiv us$.
 
@@ -1027,52 +1030,52 @@ is defined as follows:
   $\operatorname{isList}$ predicate, that there exists $l',hd$ such
   that
   \begin{mathpar}
-    \hoareV{\operatorname{isList} l~(v::vs') * \operatorname{isList} acc~us}{l}{r.r=\Inj2 hd * l = r * hd\pointsto(v,l') * \operatorname{isList} l'~vs' * \operatorname{isList} acc~us}
+    \hoareV{\isList {l} {(v::vs')} * \isList {acc} {us}}{l}{r.r=\Inj2 hd * l = r * hd\pointsto(v,l') * \isList {l'} {vs'} * \isList {acc} {us}}
   \end{mathpar}
   and we are thus in the second branch of the match.
   We start by showing
   \begin{align*}
-    \hoareV{l = \Inj2 hd * hd\pointsto(v,l') * \operatorname{isList} l'~vs' * \operatorname{isList} acc~us}
+    \hoareV{l = \Inj2 hd * hd\pointsto(v,l') * \isList {l'} {vs'} * \isList {acc} {us}}
     {\begin{array}{l}
        \Let h = \Proj1 !hd in\\
        \Let t = \Proj2 !hd in\\
        hd\gets(h,acc)
      \end{array}
     }
-    {l = \Inj2 hd * hd\pointsto(v,acc) * \operatorname{isList} l'~vs' * \operatorname{isList} acc~us * h = v * t = l'}
+    {l = \Inj2 hd * hd\pointsto(v,acc) * \isList {l'} {vs'} * \isList {acc} {us} * h = v * t = l'}
   \end{align*}
   by repeated applications of \ruleref{Ht-let-det-temp} and \ruleref{Ht-Proj}.
   Clearly the proposition
   \begin{align*}
-    l = \Inj2 hd * hd\pointsto(v,acc) * \operatorname{isList} l'~vs' * \operatorname{isList} acc~us * h = v * t = l'
+    l = \Inj2 hd * hd\pointsto(v,acc) * \isList {l'} {vs'} * \isList {acc} {us} * h = v * t = l'
   \end{align*}
   implies the proposition
   \begin{align*}
-    l = \Inj2 hd * hd\pointsto(v,acc) * \operatorname{isList} t~vs' * \operatorname{isList} acc~us * h = v
+    l = \Inj2 hd * hd\pointsto(v,acc) * \isList {t} {vs'} * \isList {acc} {us} * h = v
   \end{align*}
   which is simply
   \begin{align*}
-    \operatorname{isList} t~vs' * \operatorname{isList} l~(v::us)
+    \isList {t} {vs'} * \isList {l} {(v::us)}
   \end{align*}
   by definition of the $\operatorname{isList}$ predicate.
-  Finally by using the induction hypothesis (the assumption of \ruleref{Ht-Rec}) we have 
+  Finally by using the induction hypothesis (the assumption of \ruleref{Ht-Rec}) we have
   \begin{align*}
-    \hoareV{\operatorname{isList} t~vs' * \operatorname{isList} l~(v::us)}
+    \hoareV{\isList {t} {vs'} * \isList {l} {(v::us)}}
     {\langkw{rev}(t,l)}
-    {r. \operatorname{isList} r (\operatorname{reverse} vs' \mdoubleplus v::vs)}
+    {r. \isList {r} {(\operatorname{reverse} vs' \mdoubleplus v::vs)}}
   \end{align*}
   and we are done, observing that $(\operatorname{reverse} vs' \mdoubleplus v :: vs) \equiv \operatorname{reverse} (v::vs') \mdoubleplus vs$.
 
   Thus combining all of these using the sequencing rule \ruleref{Ht-seq-temp} and the rule of consequence \ruleref{Ht-csq} we have proved
   \begin{align*}
-    \hoareV{l = \Inj2 hd * hd\pointsto(v,l') * \operatorname{isList} l'~vs' * \operatorname{isList} acc~us}
+    \hoareV{l = \Inj2 hd * hd\pointsto(v,l') * \isList {l'} {vs'} * \isList {acc} {us}}
     {\begin{array}{l}
        \Let h = \Proj1 !hd in\\
        \Let t = \Proj2 !hd in\\
        hd\gets(h,acc); \langkw{rev}(t,l)
      \end{array}
     }
-    {r. \operatorname{isList} r (\operatorname{reverse} (v::vs') \mdoubleplus vs)}
+    {r. \isList {r} {(\operatorname{reverse} (v::vs') \mdoubleplus vs)}}
   \end{align*}
   as required.
 \end{example}

--- a/sections/basic-separation-logic.tex
+++ b/sections/basic-separation-logic.tex
@@ -732,9 +732,6 @@ granularity exemplified by the following exercise.
 
 \subsection{Reasoning about Mutable Data Structures}
 
-\newcommand{\isList}[2]{\operatorname{isList}~#1~#2}
-\newcommand{\map}[2]{\operatorname{map}~#1~#2}
-
 In the following examples we will work with linked lists -- chains of
 reference cells with forward links.  In order to specify their
 behaviour we assume (as explained in

--- a/sections/basic-separation-logic.tex
+++ b/sections/basic-separation-logic.tex
@@ -773,8 +773,8 @@ To specify the next example we assume the $\operatorname{map}$ function on seque
 It is the logical function from sequences to sequences that applies $f$ at every index of the sequence:
 it is defined by the following two equations
 \begin{align*}
-  &\map{f}{[]} \equiv []\\
-  &\map{f}{(x::xs)} \equiv f x :: \map{f}{xs}
+  &\map {f} {[]} \equiv []\\
+  &\map {f} {(x::xs)} \equiv f x :: \map{f}{xs}
 \end{align*}
 
 
@@ -990,7 +990,7 @@ is defined as follows:
   
   We generalize the specification of \langkw{rev} to the following specification:
   \begin{mathpar}
-    \forall vs, us.\forall hd,acc.\hoare{\isList {hd} {vs} * \isList {acc} {us} }{\langkw{rev}(hd,acc)}{r. \isList {r} {(\operatorname{reverse} vs \mdoubleplus us)}}
+    \forall vs, us.\forall hd,acc.\hoare{\isList {hd} {vs} * \isList {acc} {us}}{\langkw{rev}(hd,acc)}{r. \isList {r} {(\operatorname{reverse} vs \mdoubleplus us)}}
   \end{mathpar}
 
   \begin{exercise}

--- a/sections/case-study-foldr.tex
+++ b/sections/case-study-foldr.tex
@@ -261,14 +261,14 @@ The following client implements a filter of some boolean predicate $p$ on a list
 \begin{align*}
 \All P. \All l. \All xs. 
 \hoareV[t]{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
-\ast \isList {l} {xs} }{\langkw{filter}(p, l)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+\ast \isList {l} {xs} }{\langkw{filter}(p, l)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \listFilter {P} {xs} \right)}
 \end{align*}
 where
 \begin{align*}
-\operatorname{listFilter} \, P \, [] &\equiv \, [] \\
-\operatorname{listFilter} \, P \, (x :: xs) &\equiv \begin{cases} \left( x :: \left( \operatorname{listFilter} \, P \, xs \right) \right)
+\listFilter {P} {[]} &\equiv \, [] \\
+\listFilter {P} {(x :: xs)} &\equiv \begin{cases} \left( x :: \left( \listFilter {P} {xs} \right) \right)
 													  & \text{if } \, P \, x = \True  \\
-\operatorname{listFilter} \, P \, xs  & \text{otherwise } \end{cases}
+\listFilter {P} {xs}  & \text{otherwise } \end{cases}
 \end{align*}
 
 The specification
@@ -283,19 +283,19 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 \begin{align*}
 \hoareV{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
 \ast \isList {l} {xs} }
-{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \listFilter {P} {xs} \right)}
  \end{align*}
-  By applying the specification for \langkw{foldr} with $\TRUE$ as $P \, x $, $\isList {a} {\left( \operatorname{listFilter} \, P \, xs \right)} $ as $I \, xs \, a $,
+  By applying the specification for \langkw{foldr} with $\TRUE$ as $P \, x $, $\isList {a} {\left( \listFilter {P} {xs} \right)} $ as $I \, xs \, a $,
   \begin{align*}
     \left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs \right)
   \end{align*}
   as $f$, $xs$ as $xs$ and $l$ as $l$ we get that
  \begin{align*}
 \hoareV{ \begin{array}{l}
-\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' (x', a')}{v. \isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)} }
+\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' (x', a')}{v. \isList {v} {\left( \listFilter {P} {(x'::ys)} \right)} }
 \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \operatorname{isList}(\Inj{1}())\, (\operatorname{listFilter} \, P \, []) \end{array}}
-{\langkw{foldr}\left(p', \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}}
+{\langkw{foldr}\left(p', \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \isList {r} {\left( \listFilter {P} {xs} \right)}}
  \end{align*}
  where $p'$ is a shorthand notation for
  \begin{align*}
@@ -308,16 +308,16 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 \ast \isList {l} {xs}  \\
 & \implies \\
 & \begin{array}{l}
-\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)}}
+\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \listFilter {P} {(x'::ys)} \right)}}
 \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\operatorname{listFilter} \, P \, [])} \end{array}
+\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}
  \end{align*}
 Since $\isList {l} {xs}$ clearly implies $\isList {l} {xs}$ we only need to show.
 \begin{enumerate}
 \item $\All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x} \\
-\implies \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)}}$
+\implies \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \listFilter {P} {(x'::ys)} \right)}}$
 \item $\TRUE \implies \operatorname{all} (\lambda x . \TRUE) \, xs$
-\item $\TRUE \implies \operatorname{isList} (\Inj{1}()) \, (\operatorname{listFilter} \, P \, [])$
+\item $\TRUE \implies \isList {(\Inj{1}())} {(\listFilter {P} {[]})}$
 \end{enumerate}
 
 \begin{exercise}

--- a/sections/case-study-foldr.tex
+++ b/sections/case-study-foldr.tex
@@ -186,7 +186,7 @@ The following client is a function that computes the sum of a list of natural nu
 The specification of the $\langkw{sumList}$ function is as follows.
 \begin{align*}
 \All l. \All xs.
-  \hoare{ \isList {l} {xs} \ast \all {operatorname{isNat}} {xs}}{\langkw{sumList} \, l}{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
+  \hoare{ \isList {l} {xs} \ast \all {\operatorname{isNat}} {xs}}{\langkw{sumList} \, l}{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 where 
 \begin{align*}
@@ -201,7 +201,7 @@ The $\isList {l} {xs}$ in the postcondition again ensures that $\langkw{sumList}
 \paragraph*{Proof of the \langkw{sumList} specification}
 Let $l$ and  $xs$ be given. By \ruleref{Ht-let-det-temp} it suffices to show
 \begin{align*}
-  \hoareV{ \isList {l} {xs} \ast \all {operatorname{isNat}} {xs}}
+  \hoareV{ \isList {l} {xs} \ast \all {\operatorname{isNat}} {xs}}
   {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), 0, l\right)}
   {r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
@@ -213,16 +213,16 @@ as $f$, $l$ as $l$, and $xs$ as $xs$ we get
 \begin{align*}
 \hoareV{ \begin{array}{l}
 \left( \All x, a. \All ys.  \hoare{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}}
+\ast \isList {l} {xs} \ast \all {\operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}}
 {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), a, l\right)}
 {r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 which is almost what we want. The difference being the precondition. By \ruleref{Ht-csq} it suffices to show
 \begin{align*}
-\isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \implies 
+\isList {l} {xs} \ast \all {\operatorname{isNat}} {xs} \implies 
 \begin{array}{l}
 \left( \All x, a. \All ys.  \hoareV{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}
+\ast \isList {l} {xs} \ast \all {\operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}
 \end{align*}
 \ie{}~it is suffices to prove  
 \begin{enumerate}

--- a/sections/case-study-foldr.tex
+++ b/sections/case-study-foldr.tex
@@ -19,12 +19,12 @@ The specification of the $\langkw{foldr}$ function is as follows.
 \All P, I. \All f \in \Val . \All xs. \All l. \hoareV[t]
 {
   \begin{array}{l}
-    \operatorname{isList} l\, xs \ast \operatorname{all} P\, xs \ast  I \, [] \, a \ast{}\\
+    \isList {l} {xs} \ast \operatorname{all} P\, xs \ast  I \, [] \, a \ast{}\\
     \left( \All x \in \Val. \All a' \in \Val. \All ys. \hoare{P x \ast I \, ys \, a'}{f \, (x, \, a')}{r. I (x::ys) r} \right)
   \end{array}
   }
 {\langkw{foldr}(f, a, l)}
-{r.  \operatorname{isList} l \ xs \ast I\, xs\, r}
+{r.  \isList {l} {xs} \ast I\, xs\, r}
 \end{align*}
 where the predicate $\operatorname{all} P\, xs$ states that $P$ holds for all elements of the list.
 It is defined by induction on the list as
@@ -36,9 +36,9 @@ It is defined by induction on the list as
 We want the specification of $\langkw{foldr}$ to capture to following:
 \begin{itemize}
 \item The third argument $l$ needs to be a linked list implementing the mathematical sequence $xs$.
-  This is captured by $\operatorname{isList} \ l \ xs$ in the precondition.
+  This is captured by $\isList {l} {xs}$ in the precondition.
 \item We do not want $\langkw{foldr}$ to change the list.
-  This is captured by having $\operatorname{isList} l \ xs$ in the postcondition.
+  This is captured by having $\isList {l} {xs}$ in the postcondition.
 \item Some clients may not want to operate on general lists but only on subsets of those (\eg{}~only on lists of odd natural numbers or lists of booleans).
   This is captured by letting the client choose a predicate $P$ and then having $\operatorname{all} P\, xs$ in the precondition force the specification to only hold for list $xs$, where $P \ x$ holds for all $x$ in $xs$.
 \item We want to be able to relate the return value $r$ to the list $xs$ we have folded.
@@ -64,7 +64,7 @@ In this case we are going to instantiate the specification of $f$ with $\langkw{
 In this sense the specification for $f$ simply says that if $x$ satisfies $P$ and the result $a'$ of folding $f$ over the subsequence $xs$ satisfies the invariant, then applying $f$ to $(x, a')$ (which is exactly what $\langkw{foldr}$ does on the sequence $(x::xs)$) gives a result, such that $I$ relates it to the sequence $(x::xs)$.
 
 \begin{remark}
-  The only place, where our concrete implementation $l$ of the list (as a linked list) is used is in $\operatorname{isList} \, l \, xs$ where it is linked to a mathematical sequence $xs$.
+  The only place, where our concrete implementation $l$ of the list (as a linked list) is used is in $\isList {l} {xs}$ where it is linked to a mathematical sequence $xs$.
   The predicates $P, I$ and $\operatorname{all}$ are all defined on mathematical sequences instead.
   In this sense we may say that the mathematical sequences are abstractions or models of our concrete lists and $P, I$ and $\operatorname{all}$ operate on these models, hence the distinction between implementation details and mathematical properties becomes clear.
 \end{remark}
@@ -78,16 +78,16 @@ Let $P, I, f, xs$ and $l$ be given. As Hoare triples are persistent and persiste
 \begin{align*}
 \All x. \All a'. \All ys. \hoare{P \, x \ast I \, ys \, a'}{f \, (x, \, a')}{r. I\, (x::ys)}
 \proves \hoareV
-{ \operatorname{isList} \, l\, xs \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
+{ \isList {l} {xs} \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
 {\langkw{foldr}(f, a, l)}
-{r.  \operatorname{isList} \, l \, xs \ast I \, xs\, r}
+{r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
 
 We proceed by \ruleref{Ht-Rec} i.e. we have to prove the specification for the body of $\langkw{foldr}$ in which we have replaced any occurrence of $\langkw{foldr}$ with the function $g$ for which
 \begin{align*}
-\All xs. \All l. \hoare{ \operatorname{isList} \, l\, xs \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
+\All xs. \All l. \hoare{ \isList {l} {xs} \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
  {g(f, a, l)}
-{r.  \operatorname{isList} \, l \, xs \ast I \, xs\, r}
+{r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
 is assumed.
 
@@ -95,23 +95,23 @@ By the definition of the $\operatorname{isList}$ predicate we have that the list
 
 In the first case we need to show
 \begin{align*}
-\hoare{ \operatorname{isList} \, l\, [] \ast \operatorname{all} P \, [] \ast  I \, [] \, a}
+\hoare{ \isList {l} {[]} \ast \operatorname{all} P \, [] \ast  I \, [] \, a}
 {\langkw{match}\ l\ \langkw{with} ...}
-{r.  \operatorname{isList} \, l \, [] \ast I \, []\, r} 
+{r.  \isList {l} {[]} \ast I \, []\, r} 
 \end{align*}
 and in the second
 \begin{align*}
-\hoare{ \operatorname{isList} \, l\, (x::xs') \ast \operatorname{all} P \, (x::xs') \ast  I \, [] \, a}
+\hoare{ \isList {l} {(x::xs')} \ast \operatorname{all} P \, (x::xs') \ast  I \, [] \, a}
 {\langkw{match}\ l\ \langkw{with} ...}
-{r.  \operatorname{isList} \, l \, xs \ast I \, xs\, r}
+{r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
 In both cases we proceed by the derived match rule from Exercise~\ref{exercise:derived-match-rule}.
 
-In the first case we have $\operatorname{isList}\, l\, [] \equiv l = \langkw{inj}_1()$ hence the first case is taken (follows by \ruleref{Ht-frame}, \ruleref{Ht-Pre-Eq} and \ruleref{Ht-ret}), thus we have to prove
+In the first case we have $\isList {l} {[]} \equiv l = \langkw{inj}_1()$ hence the first case is taken (follows by \ruleref{Ht-frame}, \ruleref{Ht-Pre-Eq} and \ruleref{Ht-ret}), thus we have to prove
 \begin{align*}
-\hoare{ \operatorname{isList} \, l\, [] \ast  I \, [] \, a}{a}{r.  \operatorname{isList} \, l \, [] \ast I \, []\, r} 
+\hoare{ \isList {l} {[]} \ast  I \, [] \, a}{a}{r.  \isList {l} {[]} \ast I \, []\, r} 
 \end{align*}
-After framing $ \operatorname{isList} \, l\, [] $ we are left with proving
+After framing $ \isList {l} {[]} $ we are left with proving
 \begin{align*}
 \hoare{ I \, [] \, a}{a}{r. I\, [] \, r} 
 \end{align*}
@@ -121,36 +121,37 @@ As $I \, [] \, r $ follows from $r = a \ast I \, [] \, a$ it suffices by \rulere
 \end{align*}
 which follows by \ruleref{Ht-frame} and \ruleref{Ht-ret}.
 
-In the second case we have $\operatorname{isList}\, l\, (x :: xs') \equiv \Exists hd, l'.l = \langkw{inj}_2 hd \ast hd \pointsto (x, l') \ast \operatorname{isList}\, l'\, xs'$. By exercise \ref{exercise:isList-second-case} we get that the second case is taken, thus we need to prove
+In the second case we have $\isList {l} {(x :: xs')} \equiv \Exists hd, l'.l = \langkw{inj}_2 hd \ast hd \pointsto (x, l') \ast \isList {l'} {xs'}$.
+By exercise \ref{exercise:isList-second-case} we get that the second case is taken, thus we need to prove
 \begin{align*}
   \hoareV{ 
-  	\operatorname{isList} \, l' \, xs' \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
+  	\isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
   {\begin{array}{l}
      \Let h= \Proj{1} \deref x_2 in\\
      \Let t = \Proj{2} \deref x_2 in\\
     	f\, (h, (g(f, a, t)))
    \end{array}}
-  {r.  \operatorname{isList} \, l \, (x::xs') \ast I \, (x::xs') \, r}
+  {r.  \isList {l} {(x::xs')} \ast I \, (x::xs') \, r}
 \end{align*}
 By simple applications of \ruleref{Ht-let-det-temp}, \ruleref{Ht-frame}, \ruleref{Ht-bind}, \ruleref{Ht-load-temp}, \ruleref{Ht-Proj} and \ruleref{Ht-ret} we need to show:
 \begin{align*}
-  \hoareV{ \operatorname{isList} \, l' \, xs' \ast \operatorname{all} P \, (x::xs) \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
+  \hoareV{ \isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs) \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
     	{f (x, g(f, a, l'))}
-  {r. \operatorname{isList} \, l \, (x::xs') \ast I \, (x::xs') \, r}
+  {r. \isList {l} {(x::xs')} \ast I \, (x::xs') \, r}
 \end{align*}
 By \ruleref{Ht-bind-det} we have to show:
 \begin{enumerate}
 \item $f\, (x , -)$ is an evaluation context.
 \item the specification
   \begin{align*}
-\hoareV{ \operatorname{isList} \, l' \, xs' \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
+\hoareV{ \isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
     	{g(f, a, l')}
-  {r. \operatorname{isList} \, l' \, xs' \ast I \, xs' \, r \ast P\, x \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
+  {r. \isList {l'} {xs'} \ast I \, xs' \, r \ast P\, x \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
 \end{align*}
 \item the specification \begin{align*}
-  \hoareV{ \operatorname{isList} \, l' \, xs' \ast I \, xs' \, v \ast P\, x \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
+  \hoareV{ \isList {l'} {xs'} \ast I \, xs' \, v \ast P\, x \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
     	{f (x, v)}
-  {r. \operatorname{isList} \, l \, (x::xs') \ast I \, (x::xs') \, r}
+  {r. \isList {l} {(x::xs')} \ast I \, (x::xs') \, r}
 \end{align*}
 \end{enumerate}
 
@@ -162,13 +163,13 @@ By \ruleref{Ht-bind-det} we have to show:
 
 \item Follows by unfolding the definition of $\operatorname{all} P (x::xs') = P \, x \ast \operatorname{all} P \, xs'$, framing $P \, x \ast l = \Inj2 hd \ast hd \pointsto (x,l')$ and then using our assumption on $g$.
 
-\item As $ \operatorname{isList} \, l' \, xs' \ast l = \Inj2 hd \ast hd \pointsto (x,l') \implies \operatorname{isList} \, l \, (x::xs') $ then it suffices by \ruleref{Ht-csq} to show
+\item As $ \isList {l'} {xs'} \ast l = \Inj2 hd \ast hd \pointsto (x,l') \implies \isList {l} {(x::xs')} $ then it suffices by \ruleref{Ht-csq} to show
   \begin{align*}
-    \hoareV{ \operatorname{isList} \, l \, (x::xs') \ast P\, x \ast I \, xs' \, v  }
+    \hoareV{ \isList {l} {(x::xs')} \ast P\, x \ast I \, xs' \, v  }
     {f x \, v}
-    {r. \operatorname{isList} \, l \, (x::xs') \ast I \, (x::xs') \, r}
+    {r. \isList {l} {(x::xs')} \ast I \, (x::xs') \, r}
   \end{align*}
-  which follows by framing $\operatorname{isList} \, l \, (x::xs')$ and using our assumption
+  which follows by framing $\isList {l} {(x::xs')}$ and using our assumption
   on $f$.
 \end{enumerate}
 
@@ -185,7 +186,7 @@ The following client is a function that computes the sum of a list of natural nu
 The specification of the $\langkw{sumList}$ function is as follows.
 \begin{align*}
 \All l. \All xs.
-  \hoare{ \operatorname{isList} \, l\, xs \ast \operatorname{all} \operatorname{isNat}\, xs}{\langkw{sumList} \, l}{r.  \operatorname{isList} \, l\, xs \ast r = \Sigma_{x \in xs} x}
+  \hoare{ \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat}\, xs}{\langkw{sumList} \, l}{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 where 
 \begin{align*}
@@ -195,14 +196,14 @@ where
 is a predicate stating that the argument is a natural number.
 
 The specification of the $\langkw{sumList}$ function states that given a list of natural numbers implemented by $l$, the result of $\langkw{sumList}\,l$ is the sum of all the natural numbers in the list.
-The $\operatorname{isList} \, l\, xs$ in the postcondition again ensures that $\langkw{sumList}$ does not change the list.
+The $\isList {l} {xs}$ in the postcondition again ensures that $\langkw{sumList}$ does not change the list.
 
 \paragraph*{Proof of the \langkw{sumList} specification}
 Let $l$ and  $xs$ be given. By \ruleref{Ht-let-det-temp} it suffices to show
 \begin{align*}
-  \hoareV{ \operatorname{isList} \, l\, xs \ast \operatorname{all} \operatorname{isNat} xs}
+  \hoareV{ \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs}
   {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), 0, l\right)}
-  {r.  \operatorname{isList} \, l\, xs \ast r = \Sigma_{x \in xs} x}
+  {r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 Using the specification for $\langkw{foldr}$, with $\operatorname{isNat}$ as $P$, $a' = \Sigma_{y \in ys } y$ as $I \, ys \, a'$, $0$ as $a$,
 \begin{align*}
@@ -212,16 +213,16 @@ as $f$, $l$ as $l$, and $xs$ as $xs$ we get
 \begin{align*}
 \hoareV{ \begin{array}{l}
 \left( \All x, a. \All ys.  \hoare{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \operatorname{isList} \, l\, xs \ast \operatorname{all} \operatorname{isNat}\, xs \ast 0 = \Sigma_{x \in []} x\end{array}}
+\ast \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat}\, xs \ast 0 = \Sigma_{x \in []} x\end{array}}
 {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), a, l\right)}
-{r.  \operatorname{isList} \, l\, xs \ast r = \Sigma_{x \in xs} x}
+{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 which is almost what we want. The difference being the precondition. By \ruleref{Ht-csq} it suffices to show
 \begin{align*}
-\operatorname{isList} \, l\, xs \ast \operatorname{all} \operatorname{isNat} xs \implies 
+\isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs \implies 
 \begin{array}{l}
 \left( \All x, a. \All ys.  \hoareV{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \operatorname{isList} \, l\, xs \ast \operatorname{all} \operatorname{isNat} xs \ast 0 = \Sigma_{x \in []} x\end{array}
+\ast \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs \ast 0 = \Sigma_{x \in []} x\end{array}
 \end{align*}
 \ie{}~it is suffices to prove  
 \begin{enumerate}
@@ -260,7 +261,7 @@ The following client implements a filter of some boolean predicate $p$ on a list
 \begin{align*}
 \All P. \All l. \All xs. 
 \hoareV[t]{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
-\ast \operatorname{isList} \, l\, xs }{\langkw{filter}(p, l)}{r.  \operatorname{isList} \, l\, xs \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+\ast \isList {l} {xs} }{\langkw{filter}(p, l)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
 \end{align*}
 where
 \begin{align*}
@@ -281,20 +282,20 @@ The specification of $\langkw{filter}$ states that given such an implementation 
 Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 \begin{align*}
 \hoareV{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
-\ast \operatorname{isList} \, l\, xs }
-{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \operatorname{isList} \, l\, xs \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+\ast \isList {l} {xs} }
+{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
  \end{align*}
-  By applying the specification for \langkw{foldr} with $\TRUE$ as $P \, x $, $\operatorname{isList} \, a  \, \left( \operatorname{listFilter} \, P \, xs \right) $ as $I \, xs \, a $,
+  By applying the specification for \langkw{foldr} with $\TRUE$ as $P \, x $, $\isList {a} {\left( \operatorname{listFilter} \, P \, xs \right)} $ as $I \, xs \, a $,
   \begin{align*}
     \left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs \right)
   \end{align*}
   as $f$, $xs$ as $xs$ and $l$ as $l$ we get that
  \begin{align*}
 \hoareV{ \begin{array}{l}
-\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \operatorname{isList} \, a'  \, \left( \operatorname{listFilter} \, P \, ys \right)}{p' (x', a')}{v. \operatorname{isList} \, v \, \left( \operatorname{listFilter} \, P \, (x'::ys) \right) }
+\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' (x', a')}{v. \isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)} }
 \right) \\
-\ast \operatorname{isList} \, l\, xs \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \operatorname{isList}(\Inj{1}())\, (\operatorname{listFilter} \, P \, []) \end{array}}
-{\langkw{foldr}\left(p', \Inj{1}(), l\right)}{r.  \operatorname{isList} \, l\, xs \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
+\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \operatorname{isList}(\Inj{1}())\, (\operatorname{listFilter} \, P \, []) \end{array}}
+{\langkw{foldr}\left(p', \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \operatorname{listFilter} \, P \, xs \right)}
  \end{align*}
  where $p'$ is a shorthand notation for
  \begin{align*}
@@ -304,17 +305,17 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
  By \ruleref{Ht-csq} we are done if we can show that
  \begin{align*}
  & \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
-\ast \operatorname{isList} \, l\, xs  \\
+\ast \isList {l} {xs}  \\
 & \implies \\
 & \begin{array}{l}
-\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \operatorname{isList} \, a'  \, \left( \operatorname{listFilter} \, P \, ys \right)}{p' \, (x', \, a')}{v.\operatorname{isList} \, v \, \left( \operatorname{listFilter} \, P \, (x'::ys) \right)}
+\left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)}}
 \right) \\
-\ast \operatorname{isList} \, l\, xs \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \operatorname{isList} (\Inj{1}()) \, (\operatorname{listFilter} \, P \, []) \end{array}
+\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\operatorname{listFilter} \, P \, [])} \end{array}
  \end{align*}
-Since $\operatorname{isList} \, l\, xs$ clearly implies $\operatorname{isList} \, l\, xs$ we only need to show.
+Since $\isList {l} {xs}$ clearly implies $\isList {l} {xs}$ we only need to show.
 \begin{enumerate}
 \item $\All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x} \\
-\implies \All x'. \All a'. \All ys. \hoare {\TRUE \ast \operatorname{isList} \, a'  \, \left( \operatorname{listFilter} \, P \, ys \right)}{p' \, (x', \, a')}{v.\operatorname{isList} \, v \, \left( \operatorname{listFilter} \, P \, (x'::ys) \right)}$
+\implies \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \operatorname{listFilter} \, P \, ys \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \operatorname{listFilter} \, P \, (x'::ys) \right)}}$
 \item $\TRUE \implies \operatorname{all} (\lambda x . \TRUE) \, xs$
 \item $\TRUE \implies \operatorname{isList} (\Inj{1}()) \, (\operatorname{listFilter} \, P \, [])$
 \end{enumerate}

--- a/sections/case-study-foldr.tex
+++ b/sections/case-study-foldr.tex
@@ -19,18 +19,18 @@ The specification of the $\langkw{foldr}$ function is as follows.
 \All P, I. \All f \in \Val . \All xs. \All l. \hoareV[t]
 {
   \begin{array}{l}
-    \isList {l} {xs} \ast \operatorname{all} P\, xs \ast  I \, [] \, a \ast{}\\
+    \isList {l} {xs} \ast \all {P} {xs} \ast  I \, [] \, a \ast{}\\
     \left( \All x \in \Val. \All a' \in \Val. \All ys. \hoare{P x \ast I \, ys \, a'}{f \, (x, \, a')}{r. I (x::ys) r} \right)
   \end{array}
   }
 {\langkw{foldr}(f, a, l)}
 {r.  \isList {l} {xs} \ast I\, xs\, r}
 \end{align*}
-where the predicate $\operatorname{all} P\, xs$ states that $P$ holds for all elements of the list.
+where the predicate $\all {P} {xs}$ states that $P$ holds for all elements of the list.
 It is defined by induction on the list as
 \begin{align*}
- \operatorname{all} P\, [] &\equiv \TRUE \\
- \operatorname{all} P\, (x::xs) &\equiv P \, x \ast \operatorname{all} P\, xs
+ \all {P} {[]} &\equiv \TRUE \\
+ \all {P} {(x::xs)} &\equiv P \, x \ast \all {P} {xs}
 \end{align*}
 
 We want the specification of $\langkw{foldr}$ to capture to following:
@@ -40,7 +40,7 @@ We want the specification of $\langkw{foldr}$ to capture to following:
 \item We do not want $\langkw{foldr}$ to change the list.
   This is captured by having $\isList {l} {xs}$ in the postcondition.
 \item Some clients may not want to operate on general lists but only on subsets of those (\eg{}~only on lists of odd natural numbers or lists of booleans).
-  This is captured by letting the client choose a predicate $P$ and then having $\operatorname{all} P\, xs$ in the precondition force the specification to only hold for list $xs$, where $P \ x$ holds for all $x$ in $xs$.
+  This is captured by letting the client choose a predicate $P$ and then having $\all {P} {xs}$ in the precondition force the specification to only hold for list $xs$, where $P \ x$ holds for all $x$ in $xs$.
 \item We want to be able to relate the return value $r$ to the list $xs$ we have folded.
   This is done by an invariant $I\, xs\, r$.
   In the case were $\langkw{foldr}$ is applied to the empty list the return value is simply the $a$ provided, hence $I$ needs to be chosen such that $I \, [] \, a$ holds.
@@ -78,14 +78,14 @@ Let $P, I, f, xs$ and $l$ be given. As Hoare triples are persistent and persiste
 \begin{align*}
 \All x. \All a'. \All ys. \hoare{P \, x \ast I \, ys \, a'}{f \, (x, \, a')}{r. I\, (x::ys)}
 \proves \hoareV
-{ \isList {l} {xs} \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
+{ \isList {l} {xs} \ast \all {P} {xs} \ast  I \, [] \, a}
 {\langkw{foldr}(f, a, l)}
 {r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
 
 We proceed by \ruleref{Ht-Rec} i.e. we have to prove the specification for the body of $\langkw{foldr}$ in which we have replaced any occurrence of $\langkw{foldr}$ with the function $g$ for which
 \begin{align*}
-\All xs. \All l. \hoare{ \isList {l} {xs} \ast \operatorname{all} P \, xs \ast  I \, [] \, a}
+\All xs. \All l. \hoare{ \isList {l} {xs} \ast \all {P} {xs} \ast  I \, [] \, a}
  {g(f, a, l)}
 {r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
@@ -95,13 +95,13 @@ By the definition of the $\operatorname{isList}$ predicate we have that the list
 
 In the first case we need to show
 \begin{align*}
-\hoare{ \isList {l} {[]} \ast \operatorname{all} P \, [] \ast  I \, [] \, a}
+\hoare{ \isList {l} {[]} \ast \all {P} {[]} \ast  I \, [] \, a}
 {\langkw{match}\ l\ \langkw{with} ...}
 {r.  \isList {l} {[]} \ast I \, []\, r} 
 \end{align*}
 and in the second
 \begin{align*}
-\hoare{ \isList {l} {(x::xs')} \ast \operatorname{all} P \, (x::xs') \ast  I \, [] \, a}
+\hoare{ \isList {l} {(x::xs')} \ast \all {P} {(x::xs')} \ast  I \, [] \, a}
 {\langkw{match}\ l\ \langkw{with} ...}
 {r.  \isList {l} {xs} \ast I \, xs\, r}
 \end{align*}
@@ -125,7 +125,7 @@ In the second case we have $\isList {l} {(x :: xs')} \equiv \Exists hd, l'.l = \
 By exercise \ref{exercise:isList-second-case} we get that the second case is taken, thus we need to prove
 \begin{align*}
   \hoareV{ 
-  	\isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
+  	\isList {l'} {xs'} \ast \all {P} {(x::xs')} \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
   {\begin{array}{l}
      \Let h= \Proj{1} \deref x_2 in\\
      \Let t = \Proj{2} \deref x_2 in\\
@@ -135,7 +135,7 @@ By exercise \ref{exercise:isList-second-case} we get that the second case is tak
 \end{align*}
 By simple applications of \ruleref{Ht-let-det-temp}, \ruleref{Ht-frame}, \ruleref{Ht-bind}, \ruleref{Ht-load-temp}, \ruleref{Ht-Proj} and \ruleref{Ht-ret} we need to show:
 \begin{align*}
-  \hoareV{ \isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs) \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
+  \hoareV{ \isList {l'} {xs'} \ast \all {P} {(x::xs)} \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
     	{f (x, g(f, a, l'))}
   {r. \isList {l} {(x::xs')} \ast I \, (x::xs') \, r}
 \end{align*}
@@ -144,7 +144,7 @@ By \ruleref{Ht-bind-det} we have to show:
 \item $f\, (x , -)$ is an evaluation context.
 \item the specification
   \begin{align*}
-\hoareV{ \isList {l'} {xs'} \ast \operatorname{all} P \, (x::xs') \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
+\hoareV{ \isList {l'} {xs'} \ast \all {P} {(x::xs')} \ast I \, [] \, a \ast l = \Inj2 hd \ast hd \pointsto (x,l')  }
     	{g(f, a, l')}
   {r. \isList {l'} {xs'} \ast I \, xs' \, r \ast P\, x \ast l = \Inj2 hd \ast hd \pointsto (x,l') }
 \end{align*}
@@ -161,7 +161,7 @@ By \ruleref{Ht-bind-det} we have to show:
   \footnote{If we hadn't let $f$ take the arguments as a tuple then we would have been stuck here as $f (x, -)$ is not an evaluation context.
   To get past this, we would need to change the specification, such that $f \, x$ would return a function $g$, that when applied to $a'$ would satisfy the current specification for $f$ \ie{} we would have to specify $f$ using a nested Hoare triple and the specification for \langkw{foldr} would then involve a nested triple inside a nested triple.}
 
-\item Follows by unfolding the definition of $\operatorname{all} P (x::xs') = P \, x \ast \operatorname{all} P \, xs'$, framing $P \, x \ast l = \Inj2 hd \ast hd \pointsto (x,l')$ and then using our assumption on $g$.
+\item Follows by unfolding the definition of $\all {P} {(x::xs')} = P \, x \ast \all {P} {xs'}$, framing $P \, x \ast l = \Inj2 hd \ast hd \pointsto (x,l')$ and then using our assumption on $g$.
 
 \item As $ \isList {l'} {xs'} \ast l = \Inj2 hd \ast hd \pointsto (x,l') \implies \isList {l} {(x::xs')} $ then it suffices by \ruleref{Ht-csq} to show
   \begin{align*}
@@ -186,7 +186,7 @@ The following client is a function that computes the sum of a list of natural nu
 The specification of the $\langkw{sumList}$ function is as follows.
 \begin{align*}
 \All l. \All xs.
-  \hoare{ \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat}\, xs}{\langkw{sumList} \, l}{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
+  \hoare{ \isList {l} {xs} \ast \all {operatorname{isNat}} {xs}}{\langkw{sumList} \, l}{r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 where 
 \begin{align*}
@@ -201,7 +201,7 @@ The $\isList {l} {xs}$ in the postcondition again ensures that $\langkw{sumList}
 \paragraph*{Proof of the \langkw{sumList} specification}
 Let $l$ and  $xs$ be given. By \ruleref{Ht-let-det-temp} it suffices to show
 \begin{align*}
-  \hoareV{ \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs}
+  \hoareV{ \isList {l} {xs} \ast \all {operatorname{isNat}} {xs}}
   {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), 0, l\right)}
   {r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
@@ -213,16 +213,16 @@ as $f$, $l$ as $l$, and $xs$ as $xs$ we get
 \begin{align*}
 \hoareV{ \begin{array}{l}
 \left( \All x, a. \All ys.  \hoare{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat}\, xs \ast 0 = \Sigma_{x \in []} x\end{array}}
+\ast \isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}}
 {\langkw{foldr}\left((\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y), a, l\right)}
 {r.  \isList {l} {xs} \ast r = \Sigma_{x \in xs} x}
 \end{align*}
 which is almost what we want. The difference being the precondition. By \ruleref{Ht-csq} it suffices to show
 \begin{align*}
-\isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs \implies 
+\isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \implies 
 \begin{array}{l}
 \left( \All x, a. \All ys.  \hoareV{\operatorname{isNat}\, x \ast a = \Sigma_{y \in ys} y}{(\lambda p, \Let x = \Proj{1} p in \Let y = \Proj{2} p in x + y) (x, \, a)}{r. r = \Sigma_{y\in (x::ys)}y} \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} \operatorname{isNat} xs \ast 0 = \Sigma_{x \in []} x\end{array}
+\ast \isList {l} {xs} \ast \all {operatorname{isNat}} {xs} \ast 0 = \Sigma_{x \in []} x\end{array}
 \end{align*}
 \ie{}~it is suffices to prove  
 \begin{enumerate}
@@ -261,7 +261,7 @@ The following client implements a filter of some boolean predicate $p$ on a list
 \begin{align*}
 \All P. \All l. \All xs. 
 \hoareV[t]{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
-\ast \isList {l} {xs} }{\langkw{filter}(p, l)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \listFilter {P} {xs} \right)}
+\ast \isList {l} {xs} }{\langkw{filter}(p, l)}{r.  \isList {l} {xs} \ast \isList {r} {\left( \listFilter {P} {xs} \right)}}
 \end{align*}
 where
 \begin{align*}
@@ -283,7 +283,7 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 \begin{align*}
 \hoareV{ \left( \All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x}\right)
 \ast \isList {l} {xs} }
-{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \operatorname{isList} \, r \left( \listFilter {P} {xs} \right)}
+{\langkw{foldr}\left(\left( \lambda y, \Let x = \Proj{1} y in \Let xs = \Proj{2} y in \If {p\, x} then \Inj{2} (\Ref (x, xs) ) \Else  xs\right), \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \isList {r} {\left( \listFilter {P} {xs} \right)}}
  \end{align*}
   By applying the specification for \langkw{foldr} with $\TRUE$ as $P \, x $, $\isList {a} {\left( \listFilter {P} {xs} \right)} $ as $I \, xs \, a $,
   \begin{align*}
@@ -294,7 +294,7 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 \hoareV{ \begin{array}{l}
 \left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' (x', a')}{v. \isList {v} {\left( \listFilter {P} {(x'::ys)} \right)} }
 \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}}
+\ast \isList {l} {xs} \ast \all {(\lambda x . \TRUE)} {xs} \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}}
 {\langkw{foldr}\left(p', \Inj{1}(), l\right)}{r.  \isList {l} {xs} \ast \isList {r} {\left( \listFilter {P} {xs} \right)}}
  \end{align*}
  where $p'$ is a shorthand notation for
@@ -310,13 +310,13 @@ Let $P, l$ and $xs$ be given. By $\ruleref{Ht-let-det-temp}$ it suffices to show
 & \begin{array}{l}
 \left(  \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \listFilter {P} {(x'::ys)} \right)}}
 \right) \\
-\ast \isList {l} {xs} \ast \operatorname{all} (\lambda x . \TRUE) \, xs \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}
+\ast \isList {l} {xs} \ast \all {(\lambda x . \TRUE)} {xs} \ast \isList {(\Inj{1}())} {(\listFilter {P} {[]})} \end{array}
  \end{align*}
 Since $\isList {l} {xs}$ clearly implies $\isList {l} {xs}$ we only need to show.
 \begin{enumerate}
 \item $\All x. \hoare{\TRUE}{p \, x}{v. \operatorname{isBool} \, v \ast v = P \, x} \\
 \implies \All x'. \All a'. \All ys. \hoare {\TRUE \ast \isList {a'} {\left( \listFilter {P} {ys} \right)}}{p' \, (x', \, a')}{v.\isList {v} {\left( \listFilter {P} {(x'::ys)} \right)}}$
-\item $\TRUE \implies \operatorname{all} (\lambda x . \TRUE) \, xs$
+\item $\TRUE \implies \all {(\lambda x . \TRUE)} {xs}$
 \item $\TRUE \implies \isList {(\Inj{1}())} {(\listFilter {P} {[]})}$
 \end{enumerate}
 

--- a/sections/inductive-coinductive-predicates.tex
+++ b/sections/inductive-coinductive-predicates.tex
@@ -20,14 +20,14 @@ as interesting exercises.\footnote{Formal proofs in Iris in Coq can be found in 
 \paragraph{Preview} 
 We have already seen two ways of defining predicates on $\tau$, which we now call to mind.
 First, recall the $\operatorname{isList}$ predicate defined in Section \ref{sec:basic-separation-logic}.
-There we explained that $\operatorname{isList} l\, xs$ relates a programming language value $l$ to a mathematical sequence of values
+There we explained that $\isList {l} {xs}$ relates a programming language value $l$ to a mathematical sequence of values
 $xs$, \ie\ $\operatorname{isList}$ is of type $\Val\to\operatorname{Seq}(\Val)\to\Prop$,
 and that it was defined by induction on the mathematical sequence $xs$.  Observe: $\operatorname{Seq}(\Val)$ is
 an Iris \emph{type} of standard mathematical sequences and we use that to define a new predicate $\operatorname{isList}$.
 Now, what if we do not care about which mathematical sequence $l$ represents, but just want to express
 that $l$ is a linked list representing some unknown sequence of elements ?
 Then we can, of course, define a new predicate
-$\operatorname{MList} : \Val\to\Prop$ by setting $\operatorname{MList} l = \Exists xs. \operatorname{isList} l\, xs$.
+$\operatorname{MList} : \Val\to\Prop$ by setting $\operatorname{MList} l = \Exists xs. \isList {l} {xs}$.
 But we could also define a predicate by guarded recursion by letting
 \begin{displaymath}
   \operatorname{GList} = \MU \phi:\Val\to\Prop. \lambda l .


### PR DESCRIPTION
I found that `isList l xs` and `map f l` was a bit hard to read in the latex as it tended to squash the space between both arguments. Hopefully this version is more legible.